### PR TITLE
feat: add toast notifications with Sonner

### DIFF
--- a/ai/decisions/ADR-007-ui-components.md
+++ b/ai/decisions/ADR-007-ui-components.md
@@ -40,3 +40,22 @@ Icons from `lucide-react`. Class name merging via `clsx` + `tailwind-merge` (exp
 - PostCSS plugin: `@tailwindcss/postcss` (not the v3 `tailwindcss` plugin)
 - Color tokens use CSS custom properties (`--background`, `--foreground`, etc.) on `:root` and `.dark`
 - `tailwind.config.ts` exists but is minimal — only `darkMode: 'class'`
+
+---
+
+## Toast notifications — Sonner
+
+**Added:** 2026-04-01
+
+Toast notifications use [Sonner](https://sonner.emilkowal.dev/) (`sonner` v2.x, ~3kb). Sonner is the shadcn/ui recommended toast library.
+
+**Why Sonner:**
+- Standalone `toast()` function — no React context or hook required to trigger toasts
+- Built-in variants: `toast.success()`, `toast.error()`, `toast()`, `toast.warning()`
+- Supports CSS variable theming — maps directly to project theme tokens
+- Accessible: manages focus, ARIA live regions, keyboard dismiss
+
+**Integration:**
+- `src/components/ui/sonner.tsx` — thin `<Toaster />` wrapper with project defaults
+- Mounted once in `src/app/layout.tsx`
+- CSS variable overrides in `src/app/globals.css` (`:root` and `.dark`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "prisma": "^5.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
+        "sonner": "^2.0.7",
         "stripe": "^21.0.1",
         "svix": "^1.89.0",
         "tailwind-merge": "^3.5.0"
@@ -6610,6 +6611,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "prisma": "^5.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
+    "sonner": "^2.0.7",
     "stripe": "^21.0.1",
     "svix": "^1.89.0",
     "tailwind-merge": "^3.5.0"

--- a/src/app/(dashboard)/settings/billing/page.tsx
+++ b/src/app/(dashboard)/settings/billing/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import { toast } from 'sonner'
 import { Check, Loader2 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
@@ -66,6 +67,12 @@ export default function BillingPage() {
   const [loading, setLoading] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
+  function showError(err: unknown) {
+    const message = err instanceof Error ? err.message : 'Something went wrong'
+    setError(message)
+    toast.error(message)
+  }
+
   async function handleCheckout(plan: PricingPlan) {
     const priceId = interval === 'monthly' ? plan.stripePriceIdMonthly : plan.stripePriceIdAnnual
     setLoading(plan.name)
@@ -74,7 +81,7 @@ export default function BillingPage() {
       const url = await startCheckout(priceId)
       if (url) window.location.href = url
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Something went wrong')
+      showError(err)
     } finally {
       setLoading(null)
     }
@@ -87,7 +94,7 @@ export default function BillingPage() {
       const url = await openPortal()
       if (url) window.location.href = url
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Something went wrong')
+      showError(err)
     } finally {
       setLoading(null)
     }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -95,6 +95,13 @@
   --ring: 224.3 76.3% 48%;
 }
 
+/* Sonner toast overrides — map normal toasts to project theme */
+[data-sonner-toaster] {
+  --normal-bg: hsl(var(--card));
+  --normal-border: hsl(var(--border));
+  --normal-text: hsl(var(--card-foreground));
+}
+
 * {
   border-color: hsl(var(--border));
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { ClerkProvider } from '@clerk/nextjs'
+import { Toaster } from '@/components/ui/sonner'
 import './globals.css'
 
 export const metadata: Metadata = {
@@ -11,7 +12,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <ClerkProvider>
       <html lang="en">
-        <body>{children}</body>
+        <body>
+          {children}
+          <Toaster />
+        </body>
       </html>
     </ClerkProvider>
   )

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { Toaster as SonnerToaster } from 'sonner'
+
+type ToasterProps = React.ComponentProps<typeof SonnerToaster>
+
+export function Toaster(props: ToasterProps) {
+  return (
+    <SonnerToaster
+      theme="system"
+      position="bottom-right"
+      richColors
+      closeButton
+      {...props}
+    />
+  )
+}


### PR DESCRIPTION
## What
- Added `sonner` v2 as a dependency for lightweight toast notifications (~3kb)
- Created a `<Toaster />` wrapper component (`src/components/ui/sonner.tsx`) with project defaults (system theme, bottom-right position, rich colors, close button)
- Mounted `<Toaster />` in the root layout (`src/app/layout.tsx`)
- Added CSS variable overrides in `globals.css` to map Sonner toast colors to existing project theme tokens
- Integrated `toast.error()` calls in the billing page error handling alongside the existing `setError()` state
- Updated ADR-007 with the Sonner decision rationale

## Why
Toast notifications provide non-blocking user feedback for async operations like checkout and portal redirects. Sonner is the shadcn/ui recommended toast library and requires no React context — just a standalone `toast()` function call.

## How to test
1. Run `npm run dev` and navigate to `/settings/billing`
2. Trigger a checkout error (e.g., with no Stripe keys configured) — you should see both the inline error message and a toast notification in the bottom-right corner
3. Verify the toast matches the project theme in both light and dark modes
4. Run `npm test`, `npm run lint`, and `npm run typecheck` to confirm no regressions

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)