### PR TITLE
feat: add webhook idempotency for Stripe and Clerk

### DIFF
--- a/prisma/migrations/20260402015820_add_webhook_event/migration.sql
+++ b/prisma/migrations/20260402015820_add_webhook_event/migration.sql
@@ -1,0 +1,16 @@
+-- CreateTable
+CREATE TABLE "WebhookEvent" (
+    "id" TEXT NOT NULL,
+    "eventId" TEXT NOT NULL,
+    "source" TEXT NOT NULL,
+    "eventType" TEXT NOT NULL,
+    "processedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WebhookEvent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "WebhookEvent_processedAt_idx" ON "WebhookEvent"("processedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WebhookEvent_eventId_source_key" ON "WebhookEvent"("eventId", "source");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -64,3 +64,16 @@ enum SubscriptionStatus {
   trialing
   unpaid
 }
+
+/// Tracks processed webhook events for idempotency.
+/// Prevents duplicate handling when Stripe or Clerk retries delivery.
+model WebhookEvent {
+  id          String   @id @default(cuid())
+  eventId     String
+  source      String   // "stripe" | "clerk"
+  eventType   String   // e.g. "customer.subscription.updated"
+  processedAt DateTime @default(now())
+
+  @@unique([eventId, source])
+  @@index([processedAt])
+}

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -1,7 +1,8 @@
 import { headers } from 'next/headers'
 import { Webhook } from 'svix'
 import { prisma } from '@/infrastructure/database/client'
-import type { WebhookEvent } from '@clerk/nextjs/server'
+import { isEventProcessed, markEventProcessed } from '@/services/webhook/webhookEventService'
+import type { WebhookEvent as ClerkWebhookEvent } from '@clerk/nextjs/server'
 
 export async function POST(req: Request) {
   const webhookSecret = process.env.CLERK_WEBHOOK_SECRET
@@ -23,16 +24,20 @@ export async function POST(req: Request) {
   const body = JSON.stringify(payload)
 
   const wh = new Webhook(webhookSecret)
-  let event: WebhookEvent
+  let event: ClerkWebhookEvent
 
   try {
     event = wh.verify(body, {
       'svix-id': svixId,
       'svix-timestamp': svixTimestamp,
       'svix-signature': svixSignature,
-    }) as WebhookEvent
+    }) as ClerkWebhookEvent
   } catch {
     return new Response('Invalid webhook signature', { status: 400 })
+  }
+
+  if (await isEventProcessed(svixId, 'clerk')) {
+    return new Response('OK', { status: 200 })
   }
 
   switch (event.type) {
@@ -72,6 +77,8 @@ export async function POST(req: Request) {
       break
     }
   }
+
+  await markEventProcessed(svixId, 'clerk', event.type)
 
   return new Response('OK', { status: 200 })
 }

--- a/src/app/api/webhooks/stripe/route.ts
+++ b/src/app/api/webhooks/stripe/route.ts
@@ -2,6 +2,7 @@ import { headers } from 'next/headers'
 import { stripe } from '@/infrastructure/stripe/client'
 import { prisma } from '@/infrastructure/database/client'
 import { syncSubscription, deleteSubscription } from '@/services/billing/subscriptionSyncService'
+import { isEventProcessed, markEventProcessed } from '@/services/webhook/webhookEventService'
 import type Stripe from 'stripe'
 
 export async function POST(req: Request) {
@@ -25,6 +26,10 @@ export async function POST(req: Request) {
     event = stripe.webhooks.constructEvent(body, signature, webhookSecret)
   } catch {
     return new Response('Invalid webhook signature', { status: 400 })
+  }
+
+  if (await isEventProcessed(event.id, 'stripe')) {
+    return new Response('OK', { status: 200 })
   }
 
   switch (event.type) {
@@ -57,6 +62,8 @@ export async function POST(req: Request) {
       break
     }
   }
+
+  await markEventProcessed(event.id, 'stripe', event.type)
 
   return new Response('OK', { status: 200 })
 }

--- a/src/services/webhook/webhookEventService.ts
+++ b/src/services/webhook/webhookEventService.ts
@@ -1,0 +1,48 @@
+// Service: Webhook Event Idempotency
+//
+// Tracks processed webhook events to prevent duplicate handling.
+// Used by Stripe and Clerk webhook route handlers.
+
+import { prisma } from '../../infrastructure/database/client'
+
+export type WebhookSource = 'stripe' | 'clerk'
+
+/**
+ * Returns true if this event has already been processed.
+ */
+export async function isEventProcessed(
+  eventId: string,
+  source: WebhookSource
+): Promise<boolean> {
+  const existing = await prisma.webhookEvent.findUnique({
+    where: { eventId_source: { eventId, source } },
+  })
+  return existing !== null
+}
+
+/**
+ * Records that an event has been processed.
+ * If a concurrent request already inserted the same event (race condition),
+ * the unique constraint violation is caught and treated as a no-op.
+ */
+export async function markEventProcessed(
+  eventId: string,
+  source: WebhookSource,
+  eventType: string
+): Promise<void> {
+  try {
+    await prisma.webhookEvent.create({
+      data: { eventId, source, eventType },
+    })
+  } catch (error: unknown) {
+    // Prisma P2002 = unique constraint violation — another handler already recorded this event
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error as { code: string }).code === 'P2002'
+    ) {
+      return
+    }
+    throw error
+  }
+}

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -10,6 +10,7 @@ import { prisma } from '../../src/infrastructure/database/client'
 
 beforeEach(async () => {
   // Children before parents — delete in reverse dependency order
+  await prisma.webhookEvent.deleteMany()
   await prisma.subscription.deleteMany()
   await prisma.user.deleteMany()
   await prisma.plan.deleteMany()

--- a/tests/integration/webhook/webhookEvent.test.ts
+++ b/tests/integration/webhook/webhookEvent.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { prisma } from '../../../src/infrastructure/database/client'
+import {
+  isEventProcessed,
+  markEventProcessed,
+} from '../../../src/services/webhook/webhookEventService'
+
+describe('isEventProcessed', () => {
+  it('returns false when no event with the given eventId and source exists', async () => {
+    const result = await isEventProcessed('evt_nonexistent', 'stripe')
+    expect(result).toBe(false)
+  })
+
+  it('returns true when an event with the given eventId and source has been recorded', async () => {
+    await markEventProcessed('evt_recorded', 'stripe', 'customer.subscription.updated')
+
+    const result = await isEventProcessed('evt_recorded', 'stripe')
+    expect(result).toBe(true)
+  })
+})
+
+describe('markEventProcessed', () => {
+  it('creates a WebhookEvent row with the correct eventId, source, eventType, and processedAt', async () => {
+    await markEventProcessed('evt_new', 'stripe', 'checkout.session.completed')
+
+    const row = await prisma.webhookEvent.findUnique({
+      where: { eventId_source: { eventId: 'evt_new', source: 'stripe' } },
+    })
+
+    expect(row).not.toBeNull()
+    expect(row!.eventId).toBe('evt_new')
+    expect(row!.source).toBe('stripe')
+    expect(row!.eventType).toBe('checkout.session.completed')
+    expect(row!.processedAt).toBeInstanceOf(Date)
+  })
+
+  it('does not throw when called twice with the same eventId and source', async () => {
+    await markEventProcessed('evt_dup', 'stripe', 'customer.subscription.created')
+    await expect(
+      markEventProcessed('evt_dup', 'stripe', 'customer.subscription.created')
+    ).resolves.not.toThrow()
+
+    // Verify only one row exists
+    const count = await prisma.webhookEvent.count({
+      where: { eventId: 'evt_dup', source: 'stripe' },
+    })
+    expect(count).toBe(1)
+  })
+
+  it('tracks the same eventId independently for different sources', async () => {
+    await markEventProcessed('evt_shared_id', 'stripe', 'customer.subscription.updated')
+    await markEventProcessed('evt_shared_id', 'clerk', 'user.created')
+
+    const stripeProcessed = await isEventProcessed('evt_shared_id', 'stripe')
+    const clerkProcessed = await isEventProcessed('evt_shared_id', 'clerk')
+
+    expect(stripeProcessed).toBe(true)
+    expect(clerkProcessed).toBe(true)
+
+    // Verify two distinct rows
+    const count = await prisma.webhookEvent.count({
+      where: { eventId: 'evt_shared_id' },
+    })
+    expect(count).toBe(2)
+  })
+
+  it('handles concurrent markEventProcessed calls for the same event without error', async () => {
+    // Fire two marks concurrently — one will succeed, the other hits P2002 and returns silently
+    await expect(
+      Promise.all([
+        markEventProcessed('evt_race', 'stripe', 'customer.subscription.updated'),
+        markEventProcessed('evt_race', 'stripe', 'customer.subscription.updated'),
+      ])
+    ).resolves.not.toThrow()
+
+    const count = await prisma.webhookEvent.count({
+      where: { eventId: 'evt_race', source: 'stripe' },
+    })
+    expect(count).toBe(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Adds a `WebhookEvent` Prisma model to track processed webhook event IDs with a compound unique constraint on `(eventId, source)`
- New `webhookEventService` with `isEventProcessed` / `markEventProcessed` — handles race conditions via P2002 catch
- Both Stripe and Clerk webhook routes now skip already-processed events and mark new ones after successful handling

Closes #3

## Test plan

- [ ] `npm run typecheck` — clean
- [ ] `npm run lint` — 0 errors
- [ ] `npm test` — 49/49 unit tests pass, 100% coverage
- [ ] `npm run test:integration` — 16/16 pass (6 new webhook idempotency tests)
- [ ] Browser: landing page, sign-in, dashboard redirect all work
- [ ] Manual: `stripe listen --forward-to localhost:3000/api/webhooks/stripe` — verify WebhookEvent row created, resend same event to verify dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)