### PR TITLE
feat: add invoice history page

### DIFF
--- a/ai/sessions/2026-04-02-feat-issue-7.md
+++ b/ai/sessions/2026-04-02-feat-issue-7.md
@@ -1,0 +1,28 @@
+# Session: feat/issue-7
+Date: 2026-04-02
+Feature: Invoice history page displaying Stripe invoices with date, amount, status, and PDF download
+
+## What was built
+Read-only invoice history page at `/dashboard/settings/billing/invoices`. Three-layer implementation: infrastructure function (`getInvoices`) fetches from Stripe API, domain module (`mapInvoice`) maps raw data to typed `InvoiceRow` using the Money module, and a Server Component renders the table with status badges and PDF download links. Handles empty states for missing stripeCustomerId and zero invoices.
+
+## Session health
+- Flow: smooth
+- Token usage: 106k/1M (11%)
+- Retries: 1 — typecheck caught nullable `invoice.status` from Stripe SDK after simplify added `toInvoiceStatus` validation
+- Compaction triggered: no
+
+## What failed and why
+No significant failures. One minor issue: after `/simplify` added runtime validation for invoice status, `npm run typecheck` caught that the Stripe SDK types `invoice.status` as `string | null`, requiring a `?? ''` fallback. Fixed immediately.
+
+## Key decisions made
+- **Server Component over Client Component** — the invoice page is read-only with no client interactivity, so a Server Component was chosen instead of the client component + API route pattern used by the billing page. This avoids an unnecessary API route.
+- **`RawInvoiceData` in domain, not `StripeInvoiceData`** — originally placed `StripeInvoiceData` (with Stripe field names) in the domain layer. Refactored per user feedback to define a domain-neutral `RawInvoiceData` type with camelCase field names, keeping Stripe-specific mapping in infrastructure. This maintains clean dependency direction.
+- **Plain HTML table over shadcn Table component** — shadcn Table wasn't installed, and adding it for a single use case wasn't justified. Used a styled `<table>` with Tailwind instead.
+- **Runtime validation for currency and status** — added `toSupportedCurrency()` and `toInvoiceStatus()` validators instead of unsafe `as` casts, catching unsupported values at runtime.
+
+## Patterns noticed
+- The initial implementation placed `StripeInvoiceData` (a type describing Stripe's API shape) in the domain layer. This is a common mistake — types named after external services belong in infrastructure. Domain should define its own input contract with neutral naming.
+- Status validation was initially an unsafe `as` cast in infrastructure. The `/simplify` code quality agent correctly flagged this.
+
+## Open questions
+- None. All acceptance criteria from issue #7 are addressed.

--- a/ai/supplementary/repo-map.md
+++ b/ai/supplementary/repo-map.md
@@ -35,6 +35,7 @@ For quick orientation, `ai/core/repo-map.md` is sufficient.
 │   ├── components/
 │   │   └── ui/                       # shadcn-style components (Button, Card, Badge, etc.)
 │   ├── domain/
+│   │   ├── invoice/                  # Invoice mapping — RawInvoiceData → InvoiceRow
 │   │   ├── money/                    # Pure monetary math (Money type, formatMoney, etc.)
 │   │   └── subscription/             # Subscription access rules (hasActiveAccess, etc.)
 │   ├── services/
@@ -46,7 +47,8 @@ For quick orientation, `ai/core/repo-map.md` is sufficient.
 │   │   ├── database/
 │   │   │   └── client.ts             # Prisma singleton — always import from here
 │   │   └── stripe/
-│   │       └── client.ts             # Stripe singleton — always import from here
+│   │       ├── client.ts             # Stripe singleton — always import from here
+│   │       └── invoices.ts           # Fetches invoices from Stripe API
 │   └── app/                          # Next.js App Router
 │       ├── layout.tsx                # Root layout — ClerkProvider wraps everything
 │       ├── globals.css               # Tailwind v4 @theme + CSS variable definitions
@@ -59,7 +61,9 @@ For quick orientation, `ai/core/repo-map.md` is sufficient.
 │       ├── (dashboard)/
 │       │   ├── layout.tsx            # Sidebar nav + user button
 │       │   ├── dashboard/page.tsx    # Dashboard home
-│       │   └── settings/billing/page.tsx  # Billing management + plan upgrade
+│       │   └── settings/billing/
+│       │       ├── page.tsx              # Billing management + plan upgrade
+│       │       └── invoices/page.tsx     # Invoice history (Server Component)
 │       └── api/
 │           ├── webhooks/
 │           │   ├── clerk/route.ts    # Syncs users from Clerk (user.created/updated/deleted)
@@ -96,6 +100,8 @@ For quick orientation, `ai/core/repo-map.md` is sufficient.
 | CheckoutService | `src/services/billing/checkoutService.ts` | Creates Stripe Checkout Session |
 | PortalService | `src/services/billing/portalService.ts` | Creates Stripe Customer Portal session |
 | SubscriptionSync | `src/services/billing/subscriptionSyncService.ts` | Upserts subscription from Stripe webhook |
+| Invoice (domain) | `src/domain/invoice/invoice.ts` | Maps raw invoice data → InvoiceRow using Money module |
+| Invoice (infra) | `src/infrastructure/stripe/invoices.ts` | Fetches invoices from Stripe API |
 | Stripe client | `src/infrastructure/stripe/client.ts` | Stripe singleton |
 | Prisma client | `src/infrastructure/database/client.ts` | Prisma singleton |
 | Clerk webhook | `src/app/api/webhooks/clerk/route.ts` | Creates/updates/deletes User in DB |
@@ -110,6 +116,7 @@ For quick orientation, `ai/core/repo-map.md` is sufficient.
 | Marketing site | `src/app/(marketing)/page.tsx` | Landing + pricing page |
 | Dashboard | `src/app/(dashboard)/dashboard/page.tsx` | Authenticated dashboard home |
 | Billing settings | `src/app/(dashboard)/settings/billing/page.tsx` | Manage/upgrade subscription |
+| Invoice history | `src/app/(dashboard)/settings/billing/invoices/page.tsx` | Read-only invoice table (Server Component) |
 | Clerk webhook | `src/app/api/webhooks/clerk/route.ts` | User sync from Clerk |
 | Stripe webhook | `src/app/api/webhooks/stripe/route.ts` | Subscription sync from Stripe |
 

--- a/src/app/(dashboard)/settings/billing/invoices/page.tsx
+++ b/src/app/(dashboard)/settings/billing/invoices/page.tsx
@@ -1,0 +1,133 @@
+import { currentUser } from '@clerk/nextjs/server'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, Download } from 'lucide-react'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { prisma } from '@/infrastructure/database/client'
+import { getInvoices } from '@/infrastructure/stripe/invoices'
+import { mapInvoice, type InvoiceRow, type InvoiceStatus } from '@/domain/invoice/invoice'
+import { formatMoney } from '@/domain/money/money'
+
+const statusVariant: Record<InvoiceStatus, 'default' | 'secondary' | 'destructive' | 'outline'> = {
+  paid: 'default',
+  open: 'secondary',
+  draft: 'outline',
+  void: 'destructive',
+  uncollectible: 'destructive',
+}
+
+function InvoiceTable({ invoices }: { invoices: InvoiceRow[] }) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-3 pr-4 font-medium">Date</th>
+            <th className="pb-3 pr-4 font-medium">Amount</th>
+            <th className="pb-3 pr-4 font-medium">Status</th>
+            <th className="pb-3 font-medium">PDF</th>
+          </tr>
+        </thead>
+        <tbody>
+          {invoices.map((invoice) => (
+            <tr key={invoice.id} className="border-b last:border-0">
+              <td className="py-3 pr-4">{invoice.date}</td>
+              <td className="py-3 pr-4">{formatMoney(invoice.amount)}</td>
+              <td className="py-3 pr-4">
+                <Badge variant={statusVariant[invoice.status]}>
+                  {invoice.status}
+                </Badge>
+              </td>
+              <td className="py-3">
+                {invoice.pdfUrl ? (
+                  <a
+                    href={invoice.pdfUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-primary hover:underline"
+                  >
+                    <Download className="h-3.5 w-3.5" />
+                    Download
+                  </a>
+                ) : (
+                  <span className="text-muted-foreground">N/A</span>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+export default async function InvoicesPage() {
+  const user = await currentUser()
+  if (!user) redirect('/sign-in')
+
+  const dbUser = await prisma.user.findUnique({
+    where: { id: user.id },
+    select: { stripeCustomerId: true },
+  })
+
+  if (!dbUser?.stripeCustomerId) {
+    return (
+      <div className="space-y-6">
+        <PageHeader />
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            No billing history yet
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  const rawInvoices = await getInvoices(dbUser.stripeCustomerId)
+  const invoices = rawInvoices.map(mapInvoice)
+
+  if (invoices.length === 0) {
+    return (
+      <div className="space-y-6">
+        <PageHeader />
+        <Card>
+          <CardContent className="py-8 text-center text-muted-foreground">
+            No invoices found
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <PageHeader />
+      <Card>
+        <CardHeader>
+          <CardTitle>Invoices</CardTitle>
+          <CardDescription>Your recent billing history.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <InvoiceTable invoices={invoices} />
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function PageHeader() {
+  return (
+    <div>
+      <Link
+        href="/dashboard/settings/billing"
+        className="mb-4 inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft className="h-3.5 w-3.5" />
+        Back to Billing
+      </Link>
+      <h1 className="text-3xl font-bold tracking-tight">Invoice History</h1>
+      <p className="mt-1 text-muted-foreground">View and download your past invoices.</p>
+    </div>
+  )
+}

--- a/src/domain/invoice/invoice.test.ts
+++ b/src/domain/invoice/invoice.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest'
+import { mapInvoice, type RawInvoiceData } from './invoice'
+import { formatMoney } from '../money/money'
+
+function makeRawInvoice(overrides: Partial<RawInvoiceData> = {}): RawInvoiceData {
+  return {
+    id: 'in_123',
+    createdAt: 1700000000,
+    amountDue: 1900,
+    currency: 'usd',
+    status: 'paid',
+    pdfUrl: 'https://pay.stripe.com/invoice/abc/pdf',
+    ...overrides,
+  }
+}
+
+describe('mapInvoice', () => {
+  it('maps raw invoice to InvoiceRow with correct fields', () => {
+    const raw = makeRawInvoice()
+    const row = mapInvoice(raw)
+
+    expect(row.id).toBe('in_123')
+    expect(row.date).toBe(new Date(1700000000 * 1000).toLocaleDateString())
+    expect(row.amount).toEqual({ amount: 1900, currency: 'USD' })
+    expect(row.status).toBe('paid')
+    expect(row.pdfUrl).toBe('https://pay.stripe.com/invoice/abc/pdf')
+  })
+
+  it('sets pdfUrl to null when not available', () => {
+    const raw = makeRawInvoice({ pdfUrl: null })
+    const row = mapInvoice(raw)
+
+    expect(row.pdfUrl).toBeNull()
+  })
+
+  it('formats zero-amount invoices as $0.00 using Money module', () => {
+    const raw = makeRawInvoice({ amountDue: 0 })
+    const row = mapInvoice(raw)
+
+    expect(row.amount).toEqual({ amount: 0, currency: 'USD' })
+    expect(formatMoney(row.amount)).toBe('$0.00')
+  })
+
+  it('maps all valid invoice statuses', () => {
+    const statuses = ['paid', 'open', 'draft', 'void', 'uncollectible'] as const
+    for (const status of statuses) {
+      const raw = makeRawInvoice({ status })
+      const row = mapInvoice(raw)
+      expect(row.status).toBe(status)
+    }
+  })
+
+  it('throws on unknown status', () => {
+    const raw = makeRawInvoice({ status: 'refunded' })
+    expect(() => mapInvoice(raw)).toThrow('Unknown invoice status: refunded')
+  })
+
+  it('handles EUR currency', () => {
+    const raw = makeRawInvoice({ currency: 'eur', amountDue: 2050 })
+    const row = mapInvoice(raw)
+
+    expect(row.amount).toEqual({ amount: 2050, currency: 'EUR' })
+    expect(formatMoney(row.amount)).toBe('€20.50')
+  })
+
+  it('throws on unsupported currency', () => {
+    const raw = makeRawInvoice({ currency: 'jpy' })
+    expect(() => mapInvoice(raw)).toThrow('Unsupported currency: jpy')
+  })
+})

--- a/src/domain/invoice/invoice.ts
+++ b/src/domain/invoice/invoice.ts
@@ -1,0 +1,49 @@
+// Domain: Invoice
+//
+// Pure mapping from raw invoice data to domain types.
+// No side effects, no external API calls, no Stripe knowledge.
+
+import { createMoney, type Currency, type Money } from '../money/money'
+
+export type InvoiceStatus = 'paid' | 'open' | 'draft' | 'void' | 'uncollectible'
+
+export type InvoiceRow = {
+  id: string
+  date: string
+  amount: Money
+  status: InvoiceStatus
+  pdfUrl: string | null
+}
+
+export type RawInvoiceData = {
+  id: string
+  createdAt: number
+  amountDue: number
+  currency: string
+  status: string
+  pdfUrl: string | null
+}
+
+const VALID_CURRENCIES: Currency[] = ['USD', 'EUR', 'GBP', 'CAD']
+const VALID_STATUSES: InvoiceStatus[] = ['paid', 'open', 'draft', 'void', 'uncollectible']
+
+function toSupportedCurrency(currency: string): Currency {
+  const upper = currency.toUpperCase()
+  if (VALID_CURRENCIES.includes(upper as Currency)) return upper as Currency
+  throw new Error(`Unsupported currency: ${currency}`)
+}
+
+function toInvoiceStatus(status: string): InvoiceStatus {
+  if (VALID_STATUSES.includes(status as InvoiceStatus)) return status as InvoiceStatus
+  throw new Error(`Unknown invoice status: ${status}`)
+}
+
+export function mapInvoice(raw: RawInvoiceData): InvoiceRow {
+  return {
+    id: raw.id,
+    date: new Date(raw.createdAt * 1000).toLocaleDateString(),
+    amount: createMoney(raw.amountDue, toSupportedCurrency(raw.currency)),
+    status: toInvoiceStatus(raw.status),
+    pdfUrl: raw.pdfUrl,
+  }
+}

--- a/src/infrastructure/stripe/invoices.test.ts
+++ b/src/infrastructure/stripe/invoices.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+vi.mock('./client', () => ({
+  stripe: {
+    invoices: {
+      list: vi.fn(),
+    },
+  },
+}))
+
+import { stripe } from './client'
+import { getInvoices } from './invoices'
+
+const mockList = vi.mocked(stripe.invoices.list)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('getInvoices', () => {
+  it('returns array of invoice data on success', async () => {
+    mockList.mockResolvedValue({
+      data: [
+        {
+          id: 'in_123',
+          created: 1700000000,
+          amount_due: 1900,
+          currency: 'usd',
+          status: 'paid',
+          invoice_pdf: 'https://pay.stripe.com/invoice/abc/pdf',
+        },
+      ],
+    } as never)
+
+    const result = await getInvoices('cus_abc')
+
+    expect(result).toHaveLength(1)
+    expect(result[0]).toEqual({
+      id: 'in_123',
+      createdAt: 1700000000,
+      amountDue: 1900,
+      currency: 'usd',
+      status: 'paid',
+      pdfUrl: 'https://pay.stripe.com/invoice/abc/pdf',
+    })
+  })
+
+  it('returns empty array when Stripe returns no invoices', async () => {
+    mockList.mockResolvedValue({ data: [] } as never)
+
+    const result = await getInvoices('cus_abc')
+
+    expect(result).toEqual([])
+  })
+
+  it('throws "stripeCustomerId is required" when given empty string', async () => {
+    await expect(getInvoices('')).rejects.toThrow('stripeCustomerId is required')
+  })
+
+  it('throws "Failed to fetch invoices" when Stripe API errors', async () => {
+    mockList.mockRejectedValue(new Error('Stripe network error'))
+
+    await expect(getInvoices('cus_abc')).rejects.toThrow('Failed to fetch invoices')
+  })
+
+  it('passes limit: 100 to Stripe', async () => {
+    mockList.mockResolvedValue({ data: [] } as never)
+
+    await getInvoices('cus_abc')
+
+    expect(mockList).toHaveBeenCalledWith({
+      customer: 'cus_abc',
+      limit: 100,
+    })
+  })
+})

--- a/src/infrastructure/stripe/invoices.ts
+++ b/src/infrastructure/stripe/invoices.ts
@@ -1,0 +1,32 @@
+// Infrastructure: Stripe Invoices
+//
+// Fetches invoice data from the Stripe API.
+// No business logic — raw data retrieval only.
+
+import { stripe } from './client'
+import type { RawInvoiceData } from '../../domain/invoice/invoice'
+
+export async function getInvoices(stripeCustomerId: string): Promise<RawInvoiceData[]> {
+  if (!stripeCustomerId) {
+    throw new Error('stripeCustomerId is required')
+  }
+
+  try {
+    const response = await stripe.invoices.list({
+      customer: stripeCustomerId,
+      limit: 100,
+    })
+
+    return response.data.map((invoice) => ({
+      id: invoice.id,
+      createdAt: invoice.created,
+      amountDue: invoice.amount_due,
+      currency: invoice.currency,
+      status: invoice.status ?? '',
+      pdfUrl: invoice.invoice_pdf ?? null,
+    }))
+  } catch (error) {
+    console.error('Failed to fetch invoices from Stripe:', error)
+    throw new Error('Failed to fetch invoices')
+  }
+}


### PR DESCRIPTION
## What
Add read-only invoice history page at `/dashboard/settings/billing/invoices` that displays the authenticated user's Stripe invoices with date, amount, status badges, and PDF download links.

Three-layer implementation:
- **Domain** (`src/domain/invoice/invoice.ts`): `RawInvoiceData` → `InvoiceRow` mapping with Money module integration, runtime validation for currency and status
- **Infrastructure** (`src/infrastructure/stripe/invoices.ts`): `getInvoices()` fetches from Stripe API (limit 100), maps Stripe fields to domain-neutral `RawInvoiceData`
- **UI** (`src/app/(dashboard)/settings/billing/invoices/page.tsx`): Server Component with table, status badges, PDF download links, and empty states

## Why
Users need visibility into their billing history without leaving the app or logging into Stripe directly.

Closes #7

## How to test
1. Run `npm test` — 61 tests pass with 100% coverage
2. Run `npm run typecheck && npm run lint` — both clean
3. Start dev server with `npm run dev`
4. Navigate to `/dashboard/settings/billing/invoices`
   - Without auth: redirects to sign-in
   - With auth, no stripeCustomerId: shows "No billing history yet"
   - With auth + stripeCustomerId + invoices: shows invoice table with date, amount, status badge, PDF download link

🤖 Generated with [Claude Code](https://claude.com/claude-code)