### PR TITLE
feat: add E2E auth setup with Clerk testing token and admin users smoke tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,14 @@ NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL=/dashboard
 STRIPE_SECRET_KEY=sk_test_REPLACE_ME
 STRIPE_WEBHOOK_SECRET=whsec_REPLACE_ME
 
+# ─────────────────────────────────────────────
+# E2E Testing (Playwright + Clerk)
+# Create a test user in Clerk Dashboard with username/password auth
+# and publicMetadata.role set to "admin"
+# ─────────────────────────────────────────────
+E2E_CLERK_USER_USERNAME=e2e-admin
+E2E_CLERK_USER_PASSWORD=REPLACE_ME
+
 # Pro plan price IDs (create these in Stripe Dashboard → Products)
 NEXT_PUBLIC_STRIPE_PRO_MONTHLY_PRICE_ID=price_REPLACE_ME
 NEXT_PUBLIC_STRIPE_PRO_ANNUAL_PRICE_ID=price_REPLACE_ME

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ test-results/summary.txt
 
 # Playwright
 playwright-report/
+playwright/.clerk/
 test-results/
 
 # Docker

--- a/ai/supplementary/repo-map.md
+++ b/ai/supplementary/repo-map.md
@@ -179,3 +179,4 @@ For quick orientation, `ai/core/repo-map.md` is sufficient.
 | `clsx` + `tailwind-merge` | Class name utilities |
 | `lucide-react` | Icons |
 | `@radix-ui/*` | Accessible UI primitives |
+| `@clerk/testing` | Clerk E2E testing utilities (dev only) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@clerk/testing": "^2.0.8",
         "@playwright/test": "^1.44.0",
         "@tailwindcss/postcss": "^4.2.2",
         "@types/node": "^20.0.0",
@@ -135,12 +136,12 @@
       "license": "MIT"
     },
     "node_modules/@clerk/backend": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.3.tgz",
-      "integrity": "sha512-I3YLnSioYFG+EVFBYm0ilN28+FC8H+hkqMgB5Pdl7AcotQOn3JhiZMqLel2H0P390p8FEJKQNnrvXk3BemeKKQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.2.4.tgz",
+      "integrity": "sha512-zEK0xE47dVZl1AAovMbiG95kxXjEt9A2RKNEmIJveuXoNdX5AK5yV6vdCEFTblhymlFAYvTr+NHIe6iJAtp50g==",
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^4.3.2",
+        "@clerk/shared": "^4.4.0",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -187,9 +188,9 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.3.2.tgz",
-      "integrity": "sha512-tYYzdY4Fxb02TO4RHoLRFzEjXJn0iFDfoKhWtGyqf2AaIgkprTksunQtX0hnVssHMr3XD/E2S00Vrb+PzX3jCQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.4.0.tgz",
+      "integrity": "sha512-3iBX7Svp2XrSIgFk4VtyVq5OZsGStkMGqVfTBbbiFCbSKQ745OfM8j/c2wgpq5QdyavesoeDA6YiMWlpZM9/ng==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -211,6 +212,33 @@
           "optional": true
         },
         "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.0.8.tgz",
+      "integrity": "sha512-p1m0CZ1GsIUkE4c5SPcapdHoH0rCBqkECgGWs4340w/LrgyVWX1+Z1auWdcX+HvY/Soi6OzThSBP+n/acBO5OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.2.4",
+        "@clerk/shared": "^4.4.0",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
           "optional": true
         }
       }
@@ -4520,6 +4548,19 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/eastasianwidth": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:check-integrity": "bash scripts/check-test-modifications.sh"
   },
   "devDependencies": {
+    "@clerk/testing": "^2.0.8",
     "@playwright/test": "^1.44.0",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^20.0.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,15 +14,21 @@ export default defineConfig({
   },
   projects: [
     {
+      name: 'setup',
+      testMatch: /global\.setup\.ts/,
+    },
+    {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'playwright/.clerk/user.json',
+      },
+      dependencies: ['setup'],
     },
   ],
-  // Start dev server automatically before e2e tests
-  // Uncomment and update when you have a dev server configured
-  // webServer: {
-  //   command: 'npm run dev',
-  //   url: 'http://localhost:3000',
-  //   reuseExistingServer: !process.env.CI,
-  // },
+  webServer: {
+    command: 'npm run dev',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+  },
 })

--- a/tests/e2e/admin-users.test.ts
+++ b/tests/e2e/admin-users.test.ts
@@ -1,0 +1,60 @@
+import { setupClerkTestingToken } from '@clerk/testing/playwright'
+import { test, expect } from '@playwright/test'
+
+test.describe('Admin Users page', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupClerkTestingToken({ page })
+    await page.goto('/dashboard/admin/users')
+  })
+
+  test('renders heading and table column headers', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Users' })).toBeVisible()
+
+    const columnHeaders = ['Email', 'Plan', 'Status', 'Joined', 'Actions']
+    for (const header of columnHeaders) {
+      await expect(
+        page.getByRole('columnheader', { name: header })
+      ).toBeVisible()
+    }
+  })
+
+  test('renders user rows or empty state', async ({ page }) => {
+    const rows = page.locator('tbody tr')
+    const emptyState = page.getByText('No users yet.')
+
+    const hasRows = await rows.count().then((count) => count > 0)
+
+    if (hasRows) {
+      await expect(rows.first()).toBeVisible()
+    } else {
+      await expect(emptyState).toBeVisible()
+    }
+  })
+
+  test('email search input is present and accepts text', async ({ page }) => {
+    const searchInput = page.getByPlaceholder('Search by email...')
+    await expect(searchInput).toBeVisible()
+    await searchInput.fill('test@example.com')
+    await expect(searchInput).toHaveValue('test@example.com')
+  })
+
+  test('status filter dropdown is present and can be changed', async ({ page }) => {
+    const select = page.locator('select')
+    await expect(select).toBeVisible()
+    await expect(select).toHaveValue('All')
+    await select.selectOption('Active')
+    await expect(select).toHaveValue('Active')
+  })
+
+  test('user rows have Clerk link with target="_blank"', async ({ page }) => {
+    const rows = page.locator('tbody tr')
+    const hasRows = await rows.count().then((count) => count > 0)
+
+    if (hasRows) {
+      const firstRow = rows.first()
+      const clerkLink = firstRow.getByRole('link', { name: 'Clerk' })
+      await expect(clerkLink).toBeVisible()
+      await expect(clerkLink).toHaveAttribute('target', '_blank')
+    }
+  })
+})

--- a/tests/e2e/global.setup.ts
+++ b/tests/e2e/global.setup.ts
@@ -1,0 +1,23 @@
+import { clerkSetup, setupClerkTestingToken } from '@clerk/testing/playwright'
+import { test as setup } from '@playwright/test'
+
+setup('authenticate as admin', async ({ page }) => {
+  await clerkSetup()
+  await setupClerkTestingToken({ page })
+
+  await page.goto('/sign-in')
+
+  await page.getByLabel('Email address or username').fill(
+    process.env.E2E_CLERK_USER_USERNAME!
+  )
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await page.getByLabel('Password').fill(
+    process.env.E2E_CLERK_USER_PASSWORD!
+  )
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await page.waitForURL('/dashboard')
+
+  await page.context().storageState({ path: 'playwright/.clerk/user.json' })
+})


### PR DESCRIPTION
## What
- Install `@clerk/testing` as dev dependency
- Add `tests/e2e/global.setup.ts` — calls `clerkSetup()`, signs in with env var credentials, saves auth state to `playwright/.clerk/user.json`
- Add `tests/e2e/admin-users.test.ts` — smoke tests verifying heading, table columns, search input, status filter, and Clerk external links
- Update `playwright.config.ts` — setup project as dependency, `storageState`, `webServer` auto-start
- Add `playwright/.clerk/` to `.gitignore`
- Add `E2E_CLERK_USER_USERNAME` / `E2E_CLERK_USER_PASSWORD` to `.env.example`

## Why
Admin pages require a signed-in admin user. Without E2E auth infrastructure, browser smoke tests can't reach protected pages. This is the foundation for all future E2E tests.

## How to test
1. Create a test user in Clerk Dashboard with username/password auth and `publicMetadata.role` set to `"admin"`
2. Copy `.env.example` → `.env.local` and fill in `E2E_CLERK_USER_USERNAME` and `E2E_CLERK_USER_PASSWORD`
3. Run `npm run test:e2e`
4. Verify the global setup authenticates and the admin users smoke tests pass

Closes #18